### PR TITLE
fix: 修复关于 MaxAge 接收值类型的错误

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -58,7 +58,7 @@ func New(slogger *slog.Logger) *gin.Engine {
 	router := gin.New()
 	_ = router.SetTrustedProxies(nil)
 	store := cookie.NewStore([]byte(config.G.Platform.AppSecret))
-	store.Options(sessions.Options{MaxAge: 30 * int(time.Minute / time.Second)})
+	store.Options(sessions.Options{MaxAge: int(30 * time.Minute.Seconds())})
 	router.Use(sessions.Sessions(fmt.Sprintf("%s-session", config.G.Platform.AppID), store))
 
 	// 服务指标

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -24,6 +24,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/gin-contrib/sessions"
@@ -57,7 +58,7 @@ func New(slogger *slog.Logger) *gin.Engine {
 	router := gin.New()
 	_ = router.SetTrustedProxies(nil)
 	store := cookie.NewStore([]byte(config.G.Platform.AppSecret))
-	store.Options(sessions.Options{MaxAge: int(30 * 60)})
+	store.Options(sessions.Options{MaxAge: 30 * int(time.Minute / time.Second)})
 	router.Use(sessions.Sessions(fmt.Sprintf("%s-session", config.G.Platform.AppID), store))
 
 	// 服务指标

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -24,7 +24,6 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/gin-contrib/sessions"
@@ -58,7 +57,7 @@ func New(slogger *slog.Logger) *gin.Engine {
 	router := gin.New()
 	_ = router.SetTrustedProxies(nil)
 	store := cookie.NewStore([]byte(config.G.Platform.AppSecret))
-	store.Options(sessions.Options{MaxAge: int(30 * time.Minute)})
+	store.Options(sessions.Options{MaxAge: int(30 * 60)})
 	router.Use(sessions.Sessions(fmt.Sprintf("%s-session", config.G.Platform.AppID), store))
 
 	// 服务指标


### PR DESCRIPTION
`time.Minute`是一个`Duration`类型，强制转换为`MaxAge`所接受的`Int`类型时会发生强制转换，对应的值将不是所需要的**30分钟**

```bash
> cat test.go && go run test.go
package main
import (
	"fmt"
	"time"
)

func main() {
	fmt.Printf("%d", 30*time.Minute)
}

1800000000000

```